### PR TITLE
Make consistent library option

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,2 +1,3 @@
 exclude_paths:
   - .github
+  - examples

--- a/README.md
+++ b/README.md
@@ -16,14 +16,23 @@ Role Variables
   - Valid values:
     - amd
     - nvidia
+- `gpu_install_library`
+  - Whether or not to install supporting GPU Libraries
+    - CUDA for Nvidia
+    - ROCm for AMD
+  - Valid values
+    - `true` to install supporting libraries
+    - `false` to skip installation of supporting libraries (Default)
 - `gpu_install_driver_version`
   - The version of the relevant drivers to install
   - Valid values depend on `vendor`
-  - This does nothing for AMD
+    - Default for Nvidia is `550.127.05`
+    - Default for AMD is `6.3.3`
 - `gpu_install_library_version`
   - Installs CUDA/ROCm with the specified version
   - Valid values depend on `vendor`
-  - This is required for AMD
+    - Default for Nvidia is `12.4`
+    - Default for AMD is `6.3.3`
 - `gpu_install_dry_run`
   - Perform a dry run without actually installing anything
   - Default is `False`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # vars file for gpu_install
 gpu_install_vendor: nvidia # Valid values: nvidia, amd
 gpu_install_driver_version: 550.127.05 # Valid values depend on what vendor
+gpu_install_library: false # Valid values: true, false
 gpu_install_library_version: false # CUDA version for Nvidia, ROCM for AMD, valid versions depend on driver version
 gpu_install_dry_run: false # Prevents actual installation
 driver_base_url:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,16 @@
 ---
 # vars file for gpu_install
 gpu_install_vendor: nvidia # Valid values: nvidia, amd
-gpu_install_driver_version: 550.127.05 # Valid values depend on what vendor
+gpu_install_driver_version: false # Valid values depend on what vendor
 gpu_install_library: false # Valid values: true, false
 gpu_install_library_version: false # CUDA version for Nvidia, ROCM for AMD, valid versions depend on driver version
 gpu_install_dry_run: false # Prevents actual installation
 driver_base_url:
   nvidia: https://us.download.nvidia.com/tesla
   amd: https://repo.radeon.com/amdgpu-install
+
+driver_version_default:
+  nvidia: 550.127.05
+
+library_version_default:
+  nvidia: 12.4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ driver_base_url:
 
 driver_version_default:
   nvidia: 550.127.05
+  amd: 6.3.3
 
 library_version_default:
   nvidia: 12.4
+  amd: 6.3.3

--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -1,9 +1,9 @@
 ---
 - name: Install Drivers
   hosts: all
-  become: True
+  become: true
   roles:
-    - role: kdvalin.gpu_install
+    - role: redhat-performance.gpu_install
       gpu_install_vendor: nvidia
       gpu_install_driver_version: 570.148.08
       gpu_install_library_version: 12.8

--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -1,0 +1,9 @@
+---
+- name: Install Drivers
+  hosts: all
+  become: True
+  roles:
+    - role: kdvalin.gpu_install
+      gpu_install_vendor: nvidia
+      gpu_install_driver_version: 570.148.08
+      gpu_install_library_version: 12.8

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,6 +15,7 @@ build_ignore:
   - test.yml
   - .gitignore
   - .github
+  - examples
 
 tags:
   - 'tools'

--- a/tasks/amd/install/redhat.yml
+++ b/tasks/amd/install/redhat.yml
@@ -23,8 +23,14 @@
   ansible.builtin.dnf:
     pkg:
       - amdgpu-dkms
-      - rocm
     state: present
   notify:
     - Reboot system
   when: not gpu_install_dry_run
+
+- name: Install ROCM
+  ansible.builtin.dnf:
+    pkg:
+      - rocm
+    state: present
+  when: not gpu_install_dry_run and gpu_install_library

--- a/tasks/amd/main.yml
+++ b/tasks/amd/main.yml
@@ -8,6 +8,15 @@
   ansible.builtin.include_tasks:
     file: "{{ gpu_install_vendor }}/pre_download/{{ ansible_distribution | lower }}.yml"
 
+- name: Set defaults
+  block:
+    - name: Set default driver version
+      ansible.builtin.set_fact:
+        gpu_install_driver_version: "{{ gpu_install_driver_version | default(driver_version_default.amd) }}"
+    - name: Set default library version
+      ansible.builtin.set_fact:
+        gpu_install_library_version: "{{ gpu_install_library_version | default(library_version_default.amd) }}"
+
 - name: Configure System
   ansible.builtin.include_tasks:
     file: "{{ gpu_install_vendor }}/install/{{ ansible_distribution | lower }}.yml"

--- a/tasks/nvidia/install/amazon.yml
+++ b/tasks/nvidia/install/amazon.yml
@@ -31,10 +31,10 @@
     mode: "0644"
     owner: root
     group: root
-  when: not gpu_install_dry_run and gpu_install_library_version
+  when: not gpu_install_dry_run and gpu_install_library
 
 - name: Install CUDA
-  when: not gpu_install_dry_run and gpu_install_library_version
+  when: not gpu_install_dry_run and gpu_install_library
   block:
     - name: Install CUDA
       no_log: true

--- a/tasks/nvidia/install/fedora.yml
+++ b/tasks/nvidia/install/fedora.yml
@@ -30,10 +30,10 @@
     mode: "0644"
     owner: root
     group: root
-  when: not gpu_install_dry_run and gpu_install_library_version
+  when: not gpu_install_dry_run and gpu_install_library
 
 - name: Install CUDA
-  when: not gpu_install_dry_run and gpu_install_library_version
+  when: not gpu_install_dry_run and gpu_install_library
   block:
     - name: Install CUDA
       no_log: true

--- a/tasks/nvidia/install/redhat.yml
+++ b/tasks/nvidia/install/redhat.yml
@@ -36,10 +36,10 @@
     mode: "0644"
     owner: root
     group: root
-  when: not gpu_install_dry_run and gpu_install_library_version
+  when: not gpu_install_dry_run and gpu_install_library
 
 - name: Install CUDA
-  when: not gpu_install_dry_run and gpu_install_library_version
+  when: not gpu_install_dry_run and gpu_install_library
   block:
     - name: Install CUDA
       no_log: true

--- a/tasks/nvidia/install/ubuntu.yml
+++ b/tasks/nvidia/install/ubuntu.yml
@@ -33,7 +33,7 @@
   when: not gpu_install_dry_run
 
 - name: Install CUDA
-  when: not gpu_install_dry_run and gpu_install_library_version
+  when: not gpu_install_dry_run and gpu_install_library
   block:
     - name: Install CUDA Keyring
       ansible.builtin.apt:

--- a/tasks/nvidia/main.yml
+++ b/tasks/nvidia/main.yml
@@ -8,6 +8,15 @@
   ansible.builtin.include_tasks:
     file: "{{ gpu_install_vendor }}/pre_download/{{ ansible_distribution | lower }}.yml"
 
+- name: Set defaults
+  block:
+    - name: Set default driver version
+      ansible.builtin.set_fact:
+        gpu_install_driver_version: "{{ gpu_install_driver_version | default(driver_version_default.nvidia) }}"
+    - name: Set default library version
+      ansible.builtin.set_fact:
+        gpu_install_library_version: "{{ gpu_install_library_version | default(library_version_default.nvidia) }}"
+
 - name: Verify driver version exists
   block:
     - name: Check Nvidia URL


### PR DESCRIPTION
This PR adds `gpu_install_library` variable to toggle whether or not to install supporting GPU libraries.

This PR also adds sane defaults for NVIDIA and AMD gpus.

# Testing
- [ ] Nvidia Driver only
- [ ] Nvidia Driver and Libraries
- [ ] AMD Driver only
- [ ] AMD Driver and Libraries
